### PR TITLE
Fix Discord Rich Presence support for Flatpak-contained build of Discord

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+builddir/
+repo/
+.flatpak-builder/

--- a/io.github.yesser_studios.Pong.yml
+++ b/io.github.yesser_studios.Pong.yml
@@ -40,5 +40,6 @@ modules:
       - type: script
         dest-filename: run.sh
         commands:
+          - for i in {0..9}; do test -S $XDG_RUNTIME_DIR/discord-ipc-$i || ln -sf {app/com.discordapp.Discord,$XDG_RUNTIME_DIR}/discord-ipc-$i; done
           - exec dotnet /app/bin/Pong.Desktop.dll
       

--- a/io.github.yesser_studios.Pong.yml
+++ b/io.github.yesser_studios.Pong.yml
@@ -9,6 +9,7 @@ finish-args:
   - --socket=wayland
   - --socket=fallback-x11
   - --share=ipc
+  - --filesystem=xdg-run/app/com.discordapp.Discord:create
 
 command: run.sh
 modules:


### PR DESCRIPTION
As per https://github.com/flathub/com.discordapp.Discord/wiki/Rich-Precense-(discord-rpc):
- **Add create access to the expected location of Discord's binaries for Rich Presence**
- **Link Discord's rich presence binary to the expected location in the wrapper script**

Also:
- Add .gitignore for generated build files