### PR TITLE
io.github.yesser_studios.Pong 1.2.2-1

### DIFF
--- a/io.github.yesser_studios.Pong.yml
+++ b/io.github.yesser_studios.Pong.yml
@@ -5,7 +5,7 @@ sdk: org.freedesktop.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.dotnet8
 finish-args:
-  - --device=dri
+  - --device=all
     # - --socket=wayland
   - --socket=x11
   - --share=ipc


### PR DESCRIPTION
Fixes #6.
This allows access to all devices, to support joystick. device:input is not yet supported in flatpak-builder.