### PR TITLE
Do not create Discord symlinks in xdg-run

### DIFF
--- a/io.github.yesser_studios.Pong.yml
+++ b/io.github.yesser_studios.Pong.yml
@@ -10,6 +10,7 @@ finish-args:
   - --socket=x11
   - --share=ipc
   - --filesystem=xdg-run/app/com.discordapp.Discord:create
+  - --filesystem=xdg-run/app/com.discordapp.DiscordCanary:create
 
 command: run.sh
 modules:

--- a/io.github.yesser_studios.Pong.yml
+++ b/io.github.yesser_studios.Pong.yml
@@ -40,6 +40,4 @@ modules:
       - type: script
         dest-filename: run.sh
         commands:
-          - for i in {0..9}; do test -S $XDG_RUNTIME_DIR/discord-ipc-$i || ln -sf {app/com.discordapp.Discord,$XDG_RUNTIME_DIR}/discord-ipc-$i; done
           - exec dotnet /app/bin/Pong.Desktop.dll
-


### PR DESCRIPTION
The Discord RPC library used by Pong already checks the Discord Flatpak directory for the socket, there's no need to symlink it to root.